### PR TITLE
chore: add docker image

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,48 @@
+name: Build docker image
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            latest
+          labels: |
+            maintainer=${{ github.repository_owner }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:noble
+
+COPY . /app
+RUN /app/dependency.sh && \
+    apt clean && \
+    git config --global --add safe.directory /work
+
+WORKDIR /work
+ENV PATH="/root/.local/bin:/root/bin:${PATH}"
+CMD [ "/bin/bash" ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ The script `dependency.sh` sets up the environment for pandoc builds.
 - Other dependencies:
   - librsvg2-bin for SVG processing
 
+### Dockerfile
+
+The `Dockerfile` is used to build the environment for pandoc builds.
+
+Usage:
+```bash
+docker run --rm -it \
+  -v $(pwd):/work \
+  ghcr.io/openxiangshan/docs-utils:latest \
+  make
+```
+
 ### Pandoc Template
 
 Customized pandoc templates for HTML and LaTeX.
@@ -47,7 +59,7 @@ All Pandoc [Lua filters](https://pandoc.org/lua-filters.html) are located in `pa
 
 ### MkDocs building environment requirements
 
-The script `requirements.sh` defines requirements for MkDocs building.
+The script `requirements.txt` defines requirements for MkDocs building.
 
 - [MkDocs-Material](https://squidfunk.github.io/mkdocs-material/)
 - Python-Markdown extensions:

--- a/dependency.sh
+++ b/dependency.sh
@@ -1,11 +1,27 @@
+#!/bin/bash
+
+set -e
+
+if [ $(id -u) -eq 0 ]; then # for docker build, skip sudo if already root
+    SUDO=
+else
+    SUDO=sudo
+fi
+
 mkdir -p ~/.local/bin
 mkdir -p ~/.local/share/pandoc/filters
 mkdir -p ~/.local/share/fonts
 
-sudo apt-get install -y librsvg2-bin
+export PATH=$PATH:~/.local/bin
+
+$SUDO apt update
+$SUDO apt install -y \
+    wget xz-utils perl make git \
+    librsvg2-bin
 
 wget https://github.com/jgm/pandoc/releases/download/3.4/pandoc-3.4-1-amd64.deb
-sudo dpkg -i pandoc-3.4-1-amd64.deb
+$SUDO dpkg -i pandoc-3.4-1-amd64.deb
+rm pandoc-3.4-1-amd64.deb
 
 wget https://github.com/lierdakil/pandoc-crossref/releases/download/v0.3.18.0/pandoc-crossref-Linux.tar.xz
 tar -xf pandoc-crossref-Linux.tar.xz -C ~/.local/bin


### PR DESCRIPTION
- add Dockerfile.
- use CI to build an official `ghcr.io/openxiangshan/docs-utils` image.
- then we can use the pre-built image in CI of the target repo to speed up the build (Run `./utils/dependency.sh` takes ~70s -> pull image takes ~20s). Refer to [official doc](https://docs.github.com/zh/actions/writing-workflows/choosing-where-your-workflow-runs/running-jobs-in-a-container).

Also:
- fix typo in README.md